### PR TITLE
Support removing single label

### DIFF
--- a/upstream_wpt_webhook/sync.py
+++ b/upstream_wpt_webhook/sync.py
@@ -217,7 +217,7 @@ def merge_upstream_pr(upstream, steps):
     steps += [MergeUpstreamStep(upstream)]
 
 def _merge_upstream_pr(config, upstream):
-    modify_upstream_pr_labels(config, 'DELETE', ['do not merge yet'], upstream)
+    remove_upstream_pr_label(config, 'do not merge yet', str(upstream))
     data = {
         'merge_method': 'rebase',
     }
@@ -225,6 +225,13 @@ def _merge_upstream_pr(config, upstream):
                          'PUT',
                          upstream_pulls(config) + '/' + str(upstream) + '/merge',
                          json=data)
+
+
+def remove_upstream_pr_label(config, label, pr_number):
+    authenticated(config,
+                  'DELETE',
+                  ('repos/%s/test/issues/%s/labels/%s' %
+                   (config['upstream_org'], pr_number, label)))
 
 
 def modify_upstream_pr_labels(config, method, labels, pr_number):
@@ -424,7 +431,7 @@ def process_closed_pr(pr_db, pull_request, steps):
         change_upstream_pr(pr_db[pr_number], 'closed', steps)
     pr_db.pop(pr_number)
 
-        
+
 def process_json_payload(config, pr_db, payload, diff_provider, branch, pre_commit_callback):
     pull_request = payload['pull_request']
     if NO_SYNC_SIGNAL in pull_request['body']:


### PR DESCRIPTION
Fix #18 

As the investigation in https://github.com/servo-automation/upstream-wpt-sync-webhook/issues/18#issuecomment-454108102, using the [DELETE method for removing single label](https://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue) works!

So, with this new method, we can only remove the `do not merge yet` label before merging the upstream PR.
